### PR TITLE
CI: build `paginate` and `watchdog` packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Define package to build
         run: |
-          set -vxeuo pipefail
+          set -vxeo pipefail
           # https://stackoverflow.com/a/3162500:
           export PACKAGE_NAME="${${{ matrix.repo }}##*/}"
           echo PACKAGE_NAME=${PACKAGE_NAME} >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
             version: "0.5.6"
           - repo: https://github.com/gorakhargosh/watchdog
             name: watchdog
-            version: "2.3.1"
+            version: "v2.3.1"
 
     steps:
       - name: Check out the repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build packages with Pyodide
 
 on:
   push:
@@ -9,9 +9,11 @@ jobs:
   run_build:
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        packages: ["https://github.com/Pylons/paginate"]
       fail-fast: false
+      matrix:
+        packages:
+          - {repo: https://github.com/Pylons/paginate, version: "0.5.6"}
+          - {repo: https://github.com/gorakhargosh/watchdog, version: "2.3.1"}
 
     steps:
       - name: Check out the repo
@@ -25,10 +27,8 @@ jobs:
       - name: Define package to build
         run: |
           set -vxeuo pipefail
-          export PACKAGE_SOURCE="${{ matrix.packages }}"
           # https://stackoverflow.com/a/3162500:
-          export PACKAGE_NAME="${PACKAGE_SOURCE##*/}"
-          echo PACKAGE_SOURCE=${PACKAGE_SOURCE} >> $GITHUB_ENV
+          export PACKAGE_NAME="${${{ matrix.packages.repo }}##*/}"
           echo PACKAGE_NAME=${PACKAGE_NAME} >> $GITHUB_ENV
 
       - name: Set up env vars for Emscripten
@@ -47,7 +47,7 @@ jobs:
       - name: Build with Pyodide
         run: |
           set -vxeuo pipefail
-          git clone ${{ env.PACKAGE_SOURCE }}
+          git clone --depth 1 --branch ${{ matrix.packages.version }} ${{ matrix.packages.repo }}
           cd ${{ env.PACKAGE_NAME }}
           pyodide build
           ls -la

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11.2
 
@@ -40,7 +40,7 @@ jobs:
           echo "EMSCRIPTEN_VERSION is $EMSCRIPTEN_VERSION"
 
       - name: Set up Emscripten
-        uses: mymindstorm/setup-emsdk@v12
+        uses: mymindstorm/setup-emsdk@v14
         with:
           version: ${{ env.EMSCRIPTEN_VERSION }}
 
@@ -52,7 +52,8 @@ jobs:
           pyodide build
           ls -la
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload built artifacts
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }}
           path: ${{ env.PACKAGE_NAME }}/dist/${{ env.PACKAGE_NAME }}-*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,10 @@ jobs:
       matrix:
         include:
           - repo: https://github.com/Pylons/paginate
+            name: paginate
             version: "0.5.6"
           - repo: https://github.com/gorakhargosh/watchdog
+            name: watchdog
             version: "2.3.1"
 
     steps:
@@ -25,13 +27,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.11.2
-
-      - name: Define package to build
-        run: |
-          set -vxeo pipefail
-          # https://stackoverflow.com/a/3162500:
-          export PACKAGE_NAME="${${{ matrix.repo }}##*/}"
-          echo PACKAGE_NAME=${PACKAGE_NAME} >> $GITHUB_ENV
 
       - name: Set up env vars for Emscripten
         run: |
@@ -50,7 +45,7 @@ jobs:
         run: |
           set -vxeuo pipefail
           git clone --depth 1 --branch ${{ matrix.version }} ${{ matrix.repo }}
-          cd ${{ env.PACKAGE_NAME }}
+          cd ${{ matrix.name }}
           pyodide build
           ls -la
           tree .
@@ -58,5 +53,5 @@ jobs:
       - name: Upload built artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PACKAGE_NAME }}
-          path: ${{ env.PACKAGE_NAME }}/dist/${{ env.PACKAGE_NAME }}-*.whl
+          name: ${{ matrix.name }}
+          path: ${{ matrix.name }}/dist/${{ matrix.name }}-*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ jobs:
           - repo: https://github.com/gorakhargosh/watchdog
             name: watchdog
             version: "v2.3.1"
+          - repo: https://github.com/gorakhargosh/watchdog
+            name: watchdog
+            version: "v3.0.0"
 
     steps:
       - name: Check out the repo
@@ -53,5 +56,5 @@ jobs:
       - name: Upload built artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.name }}
+          name: ${{ matrix.name }}-${{ matrix.version }}
           path: ${{ matrix.name }}/dist/${{ matrix.name }}-*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           echo PACKAGE_SOURCE=${PACKAGE_SOURCE} >> $GITHUB_ENV
           echo PACKAGE_NAME=${PACKAGE_NAME} >> $GITHUB_ENV
 
-      - name: Set up env vars for EMSCRIPTEN_VERSION
+      - name: Set up env vars for Emscripten
         run: |
           set -vxeuo pipefail
           pip install pyodide-build>=0.23.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        packages: [ {repo: https://github.com/Pylons/paginate, version: "0.5.6"},
-                    {repo: https://github.com/gorakhargosh/watchdog, version: "2.3.1"} ]
+        packages: [ {repo: https://github.com/Pylons/paginate, version: "0.5.6"}, {repo: https://github.com/gorakhargosh/watchdog, version: "2.3.1"} ]
 
     steps:
       - name: Check out the repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   run_build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        packages: ["https://github.com/Pylons/paginate"]
+      fail-fast: false
+
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -17,7 +22,16 @@ jobs:
         with:
           python-version: 3.11.2
 
-      - name: Set up env vars
+      - name: Define package to build
+        run: |
+          set -vxeuo pipefail
+          export PACKAGE_SOURCE="${{ matrix.packages }}"
+          # https://stackoverflow.com/a/3162500:
+          export PACKAGE_NAME="${PACKAGE_SOURCE##*/}"
+          echo PACKAGE_SOURCE=${PACKAGE_SOURCE} >> $GITHUB_ENV
+          echo PACKAGE_NAME=${PACKAGE_NAME} >> $GITHUB_ENV
+
+      - name: Set up env vars for EMSCRIPTEN_VERSION
         run: |
           set -vxeuo pipefail
           pip install pyodide-build>=0.23.0
@@ -33,7 +47,12 @@ jobs:
       - name: Build with Pyodide
         run: |
           set -vxeuo pipefail
-          git clone https://github.com/Pylons/paginate
-          cd paginate/
+          git clone ${{ env.PACKAGE_SOURCE }}
+          cd ${{ env.PACKAGE_NAME }}
           pyodide build
           ls -la
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.PACKAGE_NAME }}
+          path: ${{ env.PACKAGE_NAME }}/dist/${{ env.PACKAGE_NAME }}-*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
           cd ${{ env.PACKAGE_NAME }}
           pyodide build
           ls -la
+          tree .
 
       - name: Upload built artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        packages:
-          - {repo: https://github.com/Pylons/paginate, version: "0.5.6"}
-          - {repo: https://github.com/gorakhargosh/watchdog, version: "2.3.1"}
+        packages: [ {repo: https://github.com/Pylons/paginate, version: "0.5.6"},
+                    {repo: https://github.com/gorakhargosh/watchdog, version: "2.3.1"} ]
 
     steps:
       - name: Check out the repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  run_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.11.2
+
+    - run: |
+        set -vxeuo pipefail
+        pip install pyodide-build>=0.23.0
+        echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV
+        echo "EMSCRIPTEN_VERSION is $EMSCRIPTEN_VERSION"
+
+    - uses: mymindstorm/setup-emsdk@v12
+      with:
+        version: ${{ env.EMSCRIPTEN_VERSION }}
+
+    - run: |
+        set -vxeuo pipefail
+        git clone https://github.com/Pylons/paginate
+        cd paginate/
+        pyodide build
+        ls -la

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        packages: [ {repo: https://github.com/Pylons/paginate, version: "0.5.6"}, {repo: https://github.com/gorakhargosh/watchdog, version: "2.3.1"} ]
+        include:
+          - repo: https://github.com/Pylons/paginate
+            version: "0.5.6"
+          - repo: https://github.com/gorakhargosh/watchdog
+            version: "2.3.1"
 
     steps:
       - name: Check out the repo
@@ -26,7 +30,7 @@ jobs:
         run: |
           set -vxeuo pipefail
           # https://stackoverflow.com/a/3162500:
-          export PACKAGE_NAME="${${{ matrix.packages.repo }}##*/}"
+          export PACKAGE_NAME="${${{ matrix.repo }}##*/}"
           echo PACKAGE_NAME=${PACKAGE_NAME} >> $GITHUB_ENV
 
       - name: Set up env vars for Emscripten
@@ -45,7 +49,7 @@ jobs:
       - name: Build with Pyodide
         run: |
           set -vxeuo pipefail
-          git clone --depth 1 --branch ${{ matrix.packages.version }} ${{ matrix.packages.repo }}
+          git clone --depth 1 --branch ${{ matrix.version }} ${{ matrix.repo }}
           cd ${{ env.PACKAGE_NAME }}
           pyodide build
           ls -la

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,8 @@ jobs:
     - run: |
         set -vxeuo pipefail
         pip install pyodide-build>=0.23.0
-        echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV
+        export EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version)
+        echo EMSCRIPTEN_VERSION=${EMSCRIPTEN_VERSION} >> $GITHUB_ENV
         echo "EMSCRIPTEN_VERSION is $EMSCRIPTEN_VERSION"
 
     - uses: mymindstorm/setup-emsdk@v12

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,25 +9,31 @@ jobs:
   run_build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: 3.11.2
+      - name: Check out the repo
+        uses: actions/checkout@v4
 
-    - run: |
-        set -vxeuo pipefail
-        pip install pyodide-build>=0.23.0
-        export EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version)
-        echo EMSCRIPTEN_VERSION=${EMSCRIPTEN_VERSION} >> $GITHUB_ENV
-        echo "EMSCRIPTEN_VERSION is $EMSCRIPTEN_VERSION"
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11.2
 
-    - uses: mymindstorm/setup-emsdk@v12
-      with:
-        version: ${{ env.EMSCRIPTEN_VERSION }}
+      - name: Set up env vars
+        run: |
+          set -vxeuo pipefail
+          pip install pyodide-build>=0.23.0
+          export EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version)
+          echo EMSCRIPTEN_VERSION=${EMSCRIPTEN_VERSION} >> $GITHUB_ENV
+          echo "EMSCRIPTEN_VERSION is $EMSCRIPTEN_VERSION"
 
-    - run: |
-        set -vxeuo pipefail
-        git clone https://github.com/Pylons/paginate
-        cd paginate/
-        pyodide build
-        ls -la
+      - name: Set up Emscripten
+        uses: mymindstorm/setup-emsdk@v12
+        with:
+          version: ${{ env.EMSCRIPTEN_VERSION }}
+
+      - name: Build with Pyodide
+        run: |
+          set -vxeuo pipefail
+          git clone https://github.com/Pylons/paginate
+          cd paginate/
+          pyodide build
+          ls -la


### PR DESCRIPTION
Build the following packages:
- https://github.com/Pylons/paginate/releases/tag/0.5.6
- https://github.com/gorakhargosh/watchdog/releases/tag/v2.3.1
- https://github.com/gorakhargosh/watchdog/releases/tag/v3.0.0

Useful links:
- https://pyodide.org/en/stable/development/building-and-testing-packages.html#build-github-actions-example
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
- https://stackoverflow.com/a/3162500 (can be useful to extract the repo name from the full GH URL)